### PR TITLE
:book: resolve broken links in documentation

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -11,7 +11,7 @@ The purpose of this policy is to ensure a smooth on-boarding and off-boarding pr
 
 2. On-boarding Process:
 2.1. Access Request:
-- New members shall submit an access request, via a blank GitHub issue from the KubeStellar repository, mentioning all members of the [OWNERS](./OWNERS) file.
+- New members shall submit an access request, via a blank GitHub issue from the KubeStellar repository, mentioning all members of the [OWNERS](https://github.com/kubestellar/kubestellar/blob/main/OWNERS) file.
 - The access request should include the member's GitHub username and a brief description of their role and contributions to the KubeStellar project.
 
 2.2. Review and Approval:
@@ -24,7 +24,7 @@ The purpose of this policy is to ensure a smooth on-boarding and off-boarding pr
 - Be sure to join the [KubeStellar-dev Google Group](https://groups.google.com/g/kubestellar-dev) to get access to important artifacts like proposals, diagrams, and meeting invitations.
 
 2.4. Orientation:
-- Newly on-boarded members will be provided with [contribution guidelines](./CONTRIBUTING.md).
+- Newly on-boarded members will be provided with [contribution guidelines](https://github.com/kubestellar/kubestellar/blob/main/CONTRIBUTING.md).
 - The guide will include instructions on how to access relevant repositories, participate in discussions, and contribute to ongoing projects.
 
 3. Off-boarding Process:
@@ -41,7 +41,7 @@ The purpose of this policy is to ensure a smooth on-boarding and off-boarding pr
 - Documentation or guidelines related to ongoing projects should be updated and made available to the team for seamless continuity.
 
 4. Code of Conduct:
-- All members of the KubeStellar GitHub organization are expected to adhere to the organization's [code of conduct](./CODE_OF_CONDUCT.md), promoting a respectful and inclusive environment.
+- All members of the KubeStellar GitHub organization are expected to adhere to the organization's [code of conduct](https://github.com/kubestellar/kubestellar/blob/main/CODE_OF_CONDUCT.md), promoting a respectful and inclusive environment.
 - Violations of the code of conduct will be addressed following the organization's established procedures for handling such incidents.
 
 5. Policy Compliance:

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -11,7 +11,7 @@ The purpose of this policy is to ensure a smooth on-boarding and off-boarding pr
 
 2. On-boarding Process:
 2.1. Access Request:
-- New members shall submit an access request, via a blank GitHub issue from the KubeStellar repository, mentioning all members of the [OWNERS](https://github.com/kubestellar/kubestellar/OWNERS) file.
+- New members shall submit an access request, via a blank GitHub issue from the KubeStellar repository, mentioning all members of the [OWNERS](./OWNERS) file.
 - The access request should include the member's GitHub username and a brief description of their role and contributions to the KubeStellar project.
 
 2.2. Review and Approval:
@@ -24,7 +24,7 @@ The purpose of this policy is to ensure a smooth on-boarding and off-boarding pr
 - Be sure to join the [KubeStellar-dev Google Group](https://groups.google.com/g/kubestellar-dev) to get access to important artifacts like proposals, diagrams, and meeting invitations.
 
 2.4. Orientation:
-- Newly on-boarded members will be provided with [contribution guidelines](https://github.com/kubestellar/kubestellar/CONTRIBUTING.MD).
+- Newly on-boarded members will be provided with [contribution guidelines](./CONTRIBUTING.md).
 - The guide will include instructions on how to access relevant repositories, participate in discussions, and contribute to ongoing projects.
 
 3. Off-boarding Process:
@@ -41,7 +41,7 @@ The purpose of this policy is to ensure a smooth on-boarding and off-boarding pr
 - Documentation or guidelines related to ongoing projects should be updated and made available to the team for seamless continuity.
 
 4. Code of Conduct:
-- All members of the KubeStellar GitHub organization are expected to adhere to the organization's [code of conduct](https://github.com/kubestellar/kubestellar/CODE_OF_CONDUCT.md), promoting a respectful and inclusive environment.
+- All members of the KubeStellar GitHub organization are expected to adhere to the organization's [code of conduct](./CODE_OF_CONDUCT.md), promoting a respectful and inclusive environment.
 - Violations of the code of conduct will be addressed following the organization's established procedures for handling such incidents.
 
 5. Policy Compliance:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For usage, architecture, and other documentation, see [the website](https://kube
 
 ## Contributing
 
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](./CONTRIBUTING.md) guide and be sure to look at `main` or the release of interest to you.
+We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](https://github.com/kubestellar/kubestellar/blob/main/CONTRIBUTING.md) guide and be sure to look at `main` or the release of interest to you.
 
 This community has a [Code of Conduct](./CODE_OF_CONDUCT.md). Please make sure to follow it.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For usage, architecture, and other documentation, see [the website](https://kube
 
 ## Contributing
 
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](https://docs.kubestellar.io/stable/Contribution%20guidelines/CONTRIBUTING/) guide and be sure to look at `main` or the release of interest to you.
+We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](./CONTRIBUTING.md) guide and be sure to look at `main` or the release of interest to you.
 
 This community has a [Code of Conduct](./CODE_OF_CONDUCT.md). Please make sure to follow it.
 

--- a/docs/content/direct/example-wecs.md
+++ b/docs/content/direct/example-wecs.md
@@ -1,6 +1,6 @@
 The following steps show how to create two new `kind` clusters and
 register them with the hub as described in the
-[official open cluster management docs](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/).
+[official open cluster management docs](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/).
 
 Note that `kind` does not support three or more concurrent clusters unless you raise some limits as described in this `kind` "known issue": [Pod errors due to “too many open files”](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files).
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
When I am going through the docs and CONTRIBUTING.MD or Readme.md I figure out most of the links are broken
## Related issue(s)

Fixes #
